### PR TITLE
feat: add auto-release workflow and update build config

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,50 @@
+name: Auto Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.0.0)'
+        type: string
+        required: false
+      name:
+        description: 'The name of the person to release the version'
+        type: string
+        required: false
+      email:
+        description: 'The email of the person to release the version'
+        type: string
+        required: false
+      timezone:
+        description: 'The timezone in the debian changelog file'
+        required: false
+        type: string
+        default: 'Asia/Shanghai'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.0.0)'
+        type: string
+        required: true
+      name:
+        description: 'The name of the person to release the version'
+        type: string
+        required: false
+      email:
+        description: 'The email of the person to release the version'
+        type: string
+        required: false
+      timezone:
+        description: 'The timezone in the debian changelog file'
+        required: false
+        type: string
+        default: 'Asia/Shanghai'
+
+jobs:
+  auto_tag:
+    uses: linuxdeepin/.github/.github/workflows/auto-release.yml@master
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      name: ${{ inputs.name }}
+      email: ${{ inputs.email }}
+      timezone: ${{ inputs.timezone }}

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: ComixHe <heyuming@deepin.org>
 pkgname=dtk6systemsettings-git
-pkgver=6.0.0
+pkgver=6.6.20
 pkgrel=1
 sourcename=dtk6systemsettings
 sourcetars=("$sourcename"_"$pkgver".tar.xz)
@@ -28,8 +28,7 @@ build() {
     -DQCH_INSTALL_DESTINATION=share/doc/qt \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DDTK_VERSION=$version
+    -DCMAKE_BUILD_TYPE=Release
   ninja
 }
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,9 +5,8 @@ export DEB_CXXFLAGS_MAINT_APPEND = -Ofast
 
 %:
 	dh $@
-PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 # Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
 BUILD_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON -DDTK_VERSION=$(PACK_VER)
+	dh_auto_configure -- -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON


### PR DESCRIPTION
1. Added new GitHub Actions workflow for automated releases with version, name, email and timezone inputs
2. Updated PKGBUILD version from 6.0.0 to 6.6.20
3. Removed DTK_VERSION parameter from build configurations in both PKGBUILD and debian/rules
4. Simplified version parsing logic in debian/rules by removing PACK_VER variable

These changes standardize the release process and simplify build configurations while maintaining compatibility. The auto-release workflow enables both manual and automated version releases with proper metadata tracking.

feat: 添加自动发布工作流并更新构建配置

1. 新增 GitHub Actions 工作流用于自动化发布，支持版本号、姓名、邮箱和时 区输入
2. 将 PKGBUILD 版本从 6.0.0 更新至 6.6.20
3. 从 PKGBUILD 和 debian/rules 中移除 DTK_VERSION 构建参数
4. 简化 debian/rules 中的版本解析逻辑，移除了 PACK_VER 变量

这些变更标准化了发布流程并简化了构建配置，同时保持兼容性。自动发布工作流
支持手动和自动版本发布，并包含完整的元数据跟踪。